### PR TITLE
Fix registering stairs changes original node def

### DIFF
--- a/stairsplus/compat/old_moreblocks.lua
+++ b/stairsplus/compat/old_moreblocks.lua
@@ -9,7 +9,7 @@ local is_legacy_paramtype2 = stairsplus.compat.is_legacy_paramtype2
 local legacy_mode = stairsplus.settings.legacy_mode
 
 local function clean_legacy_fields(fields)
-	fields = fields or {}
+	fields = table.copy(fields) or {}
 
 	fields.drawtype = nil
 	fields.light_source = nil


### PR DESCRIPTION
Fixes https://github.com/Archtec-io/bugtracker/issues/182#issuecomment-2118781028

Change affects the following nodes on Archtec:
```lua
'nodename' old_drawtype -> new_drawtype
DIFF: 'building_blocks:grate' normal -> glasslike
DIFF: 'building_blocks:smoothglass' normal -> glasslike
DIFF: 'building_blocks:woodglass' normal -> glasslike
````